### PR TITLE
Fix Python 3 compatibility issue

### DIFF
--- a/src/geoipdb_loader/__init__.py
+++ b/src/geoipdb_loader/__init__.py
@@ -21,7 +21,7 @@ def _match_md5(fp, md5_url):
     for line in fp:
         m.update(line)
     fp.seek(0)
-    return m.hexdigest() == md5
+    return m.hexdigest() == md5.decode()
 
 
 def _atomic_write(fp, dst):


### PR DESCRIPTION
Data returned by urllib is always a byte string, so we need to decode before comparing to a regular string.